### PR TITLE
38 solve errors that lead to nightly build failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
+### Changed
+* ruff.toml : removed deprecated ruff rules ANN101 and ANN102 from excluded rules
+* Use f-string, where possible, instead of '%' style string formatting
+
+### Solved
+* src/farn/core/case.py : Changed the way how local variables get added / manipulated through code. Replaced access to `locals()` with `sys._getframe().f_locals` when manipulating local variables. This change became necessary as Python 3.13 changed the way Python's builtin `locals()` method works. See [PEP 667](https://peps.python.org/pep-0667/) for details.
+
 ### Dependencies
 * Updated to ruff>=0.8.3  (from ruff>=0.6.3)
 * Updated to pyright>=1.1.390  (from pyright>=1.1.378)

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,8 +28,6 @@ ignore = [
     "PLR0912", # Too many branches   <- @TODO: reactivate and resolve  @CLAROS, 2024-10-21
     "PLR0915", # Too many statements   <- @TODO: reactivate and resolve  @CLAROS, 2024-10-21
     # Ruff lint rules considered as too strict and hence ignored
-    "ANN101",  # Missing type annotation for `self` argument in instance methods (NOTE: also listed as deprecated by Ruff)
-    "ANN102",  # Missing type annotation for `cls` argument in class methods (NOTE: also listed as deprecated by Ruff)
     "FIX002",  # Line contains TODO, consider resolving the issue
     "TD003",   # Missing issue link on the line following a TODO
     "S101",    # Use of assert detected

--- a/src/farn/cli/farn.py
+++ b/src/farn/cli/farn.py
@@ -300,13 +300,7 @@ def _generate_barnsley_fern() -> None:
         screen_width = root.winfo_screenwidth()
         screen_height = root.winfo_screenheight()
         root.geometry(
-            "%dx%d+%d+%d"
-            % (
-                x_size,
-                y_size,
-                screen_width / 2 - x_size / 2,
-                screen_height / 2 - y_size / 2,
-            )
+            newGeometry=f"{x_size}x{y_size}+{int(screen_width / 2 - x_size / 2)}+{int(screen_height / 2 - y_size / 2)}"
         )
         image = tk.PhotoImage(file=temp_file)
         canvas = tk.Canvas(root, height=y_size, width=x_size, bg="dark slate gray")

--- a/src/farn/core/case.py
+++ b/src/farn/core/case.py
@@ -264,8 +264,8 @@ class Case:
     def __str__(self) -> str:
         return str(self.to_dict())
 
-    def __eq__(self, __o: object) -> bool:
-        return str(self) == str(__o)
+    def __eq__(self, other: object) -> bool:
+        return str(self) == str(other)
 
 
 class Cases(list[Case]):

--- a/src/farn/core/case.py
+++ b/src/farn/core/case.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 from collections.abc import MutableMapping, MutableSequence, Sequence
 from copy import deepcopy
 from enum import IntEnum
@@ -136,7 +137,7 @@ class Case:
                 )
                 return False
 
-        # transfer a white list of case properties to locals() for subsequent filtering
+        # transfer a white list of case properties to frame.f_locals for subsequent filtering
         available_vars: set[str] = set()
         for attribute in dir(self):
             try:
@@ -150,7 +151,7 @@ class Case:
                     "condition",
                     "command_sets",
                 ]:
-                    locals()[attribute] = eval(f"self.{attribute}")  # noqa: S307
+                    sys._getframe().f_locals[attribute] = eval(f"self.{attribute}")  # noqa: S307, SLF001  # type: ignore[reportPrivateUsage]
                     available_vars.add(attribute)
             except Exception:  # noqa: PERF203
                 logger.exception(
@@ -164,7 +165,7 @@ class Case:
         for parameter in self.parameters:
             if parameter.name and not re.match("^_", parameter.name):
                 try:
-                    exec(f"{parameter.name} = {parameter.value}")  # noqa: S102
+                    sys._getframe().f_locals[parameter.name] = parameter.value  # noqa: SLF001  # type: ignore[reportPrivateUsage]
                     available_vars.add(parameter.name)
                 except Exception:
                     logger.exception(

--- a/src/farn/sampling/sampling.py
+++ b/src/farn/sampling/sampling.py
@@ -601,7 +601,7 @@ class DiscreteSampling:
         self,
         samples: dict[str, list[Any]],
     ) -> None:
-        _format_specifier: str = f"0{self.leading_zeros}i"
+        _format_specifier: str = f"0{self.leading_zeros}d"
         self.case_names = [f"{self.layer_name}_{format(i, _format_specifier)}" for i in range(self.number_of_samples)]
         samples["_case_name"] = self.case_names
 

--- a/src/farn/sampling/sampling.py
+++ b/src/farn/sampling/sampling.py
@@ -437,7 +437,7 @@ class DiscreteSampling:
         sobol_engine: Sobol = Sobol(
             d=self.number_of_fields,
             scramble=False,
-            seed=None,
+            rng=None,
         )
 
         if self.onset > 0:
@@ -601,9 +601,8 @@ class DiscreteSampling:
         self,
         samples: dict[str, list[Any]],
     ) -> None:
-        self.case_names = [
-            f'{self.layer_name}_{format(i, "0%i" % self.leading_zeros)}' for i in range(self.number_of_samples)
-        ]
+        _format_specifier: str = f"0{self.leading_zeros}i"
+        self.case_names = [f"{self.layer_name}_{format(i, _format_specifier)}" for i in range(self.number_of_samples)]
         samples["_case_name"] = self.case_names
 
     def _check_length_matches_number_of_names(


### PR DESCRIPTION
### Changed
* ruff.toml : removed deprecated ruff rules ANN101 and ANN102 from excluded rules
* Use f-string, where possible, instead of '%' style string formatting

### Solved
* src/farn/core/case.py : Changed the way how local variables get added / manipulated through code. Replaced access to `locals()` with `sys._getframe().f_locals` when manipulating local variables. This change became necessary as Python 3.13 changed the way Python's builtin `locals()` method works. See [PEP 667](https://peps.python.org/pep-0667/) for details.