### PR TITLE
42 change file name of cli module from farnpy to   main  py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [Unreleased]
 
--/-
+### Changed
+* Renamed the CLI module (in folder src/farn/cli) from 'farn.py' to '\_\_main\_\_.py'.
+  This follows current best practice (as in python_project_template).
+  It avoids import errors caused by the fact that the cli module has the same name as the package it imports from.
 
 
 ## [0.4.1] - 2025-01-19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ native-tls = true
 
 
 [project.scripts]
-farn = "farn.cli.farn:main"
+farn = "farn.cli.__main__:main"
 batchProcess = "farn.run.cli.batchProcess:main"
 
 

--- a/src/farn/cli/__main__.py
+++ b/src/farn/cli/__main__.py
@@ -7,15 +7,8 @@ import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
-# Remove current directory from Python search path.
-# Only through this trick it is possible that the current CLI file 'farn.py'
-# carries the same name as the package 'farn' we import from in the next lines.
-# If we did NOT remove the current directory from the Python search path,
-# Python would start searching for the imported names within the current file (farn.py)
-# instead of the package 'farn' (and the import statements fail).
-sys.path = [path for path in sys.path if Path(path) != Path(__file__).parent]
-from farn import run_farn  # noqa: E402
-from farn.utils.logging import configure_logging  # noqa: E402
+from farn import run_farn
+from farn.utils.logging import configure_logging
 
 logger = logging.getLogger(__name__)
 

--- a/tests/cli/test_farn_cli.py
+++ b/tests/cli/test_farn_cli.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from farn.cli import farn
-from farn.cli.farn import _argparser, main
+from farn.cli import __main__
+from farn.cli.__main__ import _argparser, main
 
 # *****Test commandline interface (CLI)************************************************************
 
@@ -149,8 +149,8 @@ def test_logging_configuration(
     ):
         pass
 
-    monkeypatch.setattr(farn, "configure_logging", fake_configure_logging)
-    monkeypatch.setattr(farn, "run_farn", fake_run_farn)
+    monkeypatch.setattr(__main__, "configure_logging", fake_configure_logging)
+    monkeypatch.setattr(__main__, "run_farn", fake_run_farn)
     # Execute
     if isinstance(expected, ConfigureLoggingArgs):
         args_expected: ConfigureLoggingArgs = expected
@@ -230,7 +230,7 @@ def test_api_invokation(
         args.batch = batch
         args.test = test
 
-    monkeypatch.setattr(farn, "run_farn", fake_run_farn)
+    monkeypatch.setattr(__main__, "run_farn", fake_run_farn)
     # Execute
     if isinstance(expected, ApiArgs):
         args_expected: ApiArgs = expected


### PR DESCRIPTION
* Renamed the CLI module (in folder src/farn/cli) from 'farn.py' to '\_\_main\_\_.py'.
  This follows current best practice (as in python_project_template).
  It avoids import errors caused by the fact that the cli module has the same name as the package it imports from.