### PR TITLE
Fix regression introduced with 050

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 * -/-
 
 
+## [0.5.1] - 2026-04-10
+
+### Solved
+* Fixed a regression introduced with [0.5.0] where imports from `farn.core` did not work as before (i.e. in [0.4.4]). That has not been an intended change but a regression. Hence corrected with release [0.5.1]
+
+
 ## [0.5.0] - 2026-04-09
 
 ### BREAKING Changes
@@ -595,7 +601,9 @@ Users are encouraged to update to this version.
 * Added support for Python 3.10
 
 <!-- Markdown link & img dfn's -->
-[unreleased]: https://github.com/dnv-opensource/farn/compare/v0.4.4...HEAD
+[unreleased]: https://github.com/dnv-opensource/farn/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/dnv-opensource/farn/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/dnv-opensource/farn/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/dnv-opensource/farn/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/dnv-opensource/farn/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/dnv-opensource/farn/compare/v0.4.1...v0.4.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 title: farn
-version: 0.5.0
+version: 0.5.1
 abstract: >-
   Python package to generate an n-dimensional case folder structure applying linear and spatial sampling strategies.
 type: software

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2026, DNV SE. All rights reserved."
 author = "Frank Lumpitzsch, Claas Rostock, Seunghyeon Yoo"
 
 # The full version, including alpha/beta/rc tags
-release = "0.5.0"
+release = "0.5.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ allow-direct-references = true
 
 [project]
 name = "farn"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python package to generate an n-dimensional case folder structure applying linear and spatial sampling strategies."
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/src/farn/batch/__init__.py
+++ b/src/farn/batch/__init__.py
@@ -1,1 +1,1 @@
-from farn.batch.batch_processor import AsyncBatchProcessor
+from farn.batch.batch_processor import AsyncBatchProcessor as AsyncBatchProcessor

--- a/src/farn/core/__init__.py
+++ b/src/farn/core/__init__.py
@@ -1,6 +1,6 @@
-from farn.core.parameter import Parameter
 from farn.core.case import (
-    CaseStatus,
-    Case,
-    Cases,
+    CaseStatus as CaseStatus,
+    Case as Case,
+    Cases as Cases,
 )
+from farn.core.parameter import Parameter as Parameter

--- a/src/farn/sampling/__init__.py
+++ b/src/farn/sampling/__init__.py
@@ -1,1 +1,1 @@
-from farn.sampling.discrete import DiscreteSampling
+from farn.sampling.discrete import DiscreteSampling as DiscreteSampling

--- a/uv.lock
+++ b/uv.lock
@@ -668,7 +668,7 @@ wheels = [
 
 [[package]]
 name = "farn"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "dictio" },


### PR DESCRIPTION
### Solved
* Fixed a regression introduced with [0.5.0] where imports from `farn.core` did not work as before (i.e. in [0.4.4]). That has not been an intended change but a regression. Hence corrected with release [0.5.1]
